### PR TITLE
Update authz function for FCL 0.0.67 and 0.0.68 compatibility

### DIFF
--- a/src/authorizer.ts
+++ b/src/authorizer.ts
@@ -19,28 +19,20 @@ export class KmsAuthorizer {
 
   public authorize(fromAddress: string, keyIndex: number) {
     return async (account: any = {}) => {
-      const user = await this.getAccount(fromAddress);
-      const key = user.keys[keyIndex];
-      let sequenceNum;
-      if (account.role.proposer) {
-        sequenceNum = key.sequenceNumber;
-      }
-      const signingFunction = async (data: any) => {
-        return {
-          addr: user.address,
-          keyId: key.index,
-          signature: await this.signer.sign(data.message)
-        };
-      };
       return {
         ...account,
-        addr: user.address,
-        keyId: key.index,
+        tempId: [fromAddress, keyIndex].join("-"),
+        addr: fcl.sansPrefix(fromAddress),
+        keyId: Number(keyIndex),
         sequenceNum,
-        signature: account.signature || null,
-        signingFunction,
         resolve: null,
-        roles: account.roles,
+        signingFunction: async(data: any) => {
+          return {
+            addr: fcl.withPrefix(fromAddress),
+            keyId: Number(keyIndex),
+            signature: await this.signer.sign(data.message)
+          };
+        }
       };
     };
   };


### PR DESCRIPTION
Haven't tested but I believe this should make the authorization function also compatible with fcl `0.0.67` and `0.0.68`

`FCL@0.0.67` includes the ability to auto resolve sequence number. https://github.com/onflow/flow-js-sdk/blob/master/packages/fcl/CHANGELOG.md#0067-alpha5---2020-11-19